### PR TITLE
Allows for installation (keeping all vector intrinsics) onto POWER systems.

### DIFF
--- a/basesetup.py
+++ b/basesetup.py
@@ -50,9 +50,12 @@ class CompilerDetection(object):
             self.openmp_enabled, openmp_needs_gomp = self._detect_openmp()
         self.sse3_enabled = self._detect_sse3() if not self.msvc else True
         self.sse41_enabled = self._detect_sse41() if not self.msvc else True
-        self.neon_enabled = self._detect_neon() if not self.msvc else False        
+        self.neon_enabled = self._detect_neon() if not self.msvc else False
 
-        self.compiler_args_sse2 = ['-msse2'] if not self.msvc else ['/arch:SSE2']
+        # -DNO_WARN_X86_INTRINSICS only compatible with gcc version >= 8.0 and IBM Advanced Toolchain version >= 11.0
+        # This is a direct conversions to allow x86 SSE calls to be ported to openPower Vector Intrinsics
+        # reference: https://developer.ibm.com/tutorials/migrate-app-on-lop/?_ga=2.38728486.485083667.1620858815-1927233392.1620858815&cm_mc_uid=79453381708616208588147&cm_mc_sid_50200000=72302701620930882541
+        self.compiler_args_sse2 = ['-DNO_WARN_X86_INTRINSICS -fsigned-char -msse2'] if not self.msvc else ['/arch:SSE2']
         self.compiler_args_sse3 = ['-mssse3'] if (self.sse3_enabled and not self.msvc) else []
         self.compiler_args_neon = []
         self.compiler_args_warn = ['-Wno-unused-function', '-Wno-unreachable-code', '-Wno-sign-compare'] if not self.msvc else []

--- a/mdtraj/rmsd/include/sse_swizzle.h
+++ b/mdtraj/rmsd/include/sse_swizzle.h
@@ -49,7 +49,6 @@
 #define _SSE_SWIZZLE_H_
 #include "msvccompat.h"
 #include <emmintrin.h>
-#ifdef __SSE2__
 static INLINE __m128  _mm_swizzle_ps_xxxx(__m128 reg)      {  return CAST__M128(_mm_shuffle_epi32(CAST__M128I(reg), 0x00)); }
 static INLINE __m128  _mm_swizzle_ps_xxxy(__m128 reg)      {  return CAST__M128(_mm_shuffle_epi32(CAST__M128I(reg), 0x40)); }
 static INLINE __m128  _mm_swizzle_ps_xxxz(__m128 reg)      {  return CAST__M128(_mm_shuffle_epi32(CAST__M128I(reg), 0x80)); }
@@ -562,5 +561,4 @@ static INLINE __m128  _mm_shuffle_ps_wwwx(__m128 r1, __m128 r2)      {  return _
 static INLINE __m128  _mm_shuffle_ps_wwwy(__m128 r1, __m128 r2)      {  return _mm_shuffle_ps(r1,r2,0x7F); }
 static INLINE __m128  _mm_shuffle_ps_wwwz(__m128 r1, __m128 r2)      {  return _mm_shuffle_ps(r1,r2,0xBF); }
 static INLINE __m128  _mm_shuffle_ps_wwww(__m128 r1, __m128 r2)      {  return _mm_shuffle_ps(r1,r2,0xFF); }
-#endif
 #endif


### PR DESCRIPTION
A few changes which address the `-msse2` issue referenced in several issues on original repo. These changes are made by referencing IBM's [Linux on IBM Power Systems application porting and tuning guide](https://developer.ibm.com/tutorials/migrate-app-on-lop/?_ga=2.38728486.485083667.1620858815-1927233392.1620858815&cm_mc_uid=79453381708616208588147&cm_mc_sid_50200000=72302701620930882541), and they allow for successful installation on POWER systems (Tellico POWER9 at UTK is only one tested so far).

These changes require using gcc version 8.0 or newer.